### PR TITLE
Change import position.

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import json
 import urllib
 
 import numpy as np
@@ -198,7 +199,6 @@ class FetchAddressThread(QThread):
 
         if gaode_api_key != "":
             import requests
-            import json
 
             url = 'https://restapi.amap.com/v3/geocode/geo'
             params = { 'key': gaode_api_key, 'address': self.new_place}


### PR DESCRIPTION
you put `import json` at line 201, which is inside `if gaode_api_key != ""` block, but the json module is also used at line 237, which is in the corresponding `else` block, while the `try` block silence the import error. This makes the `add-address` function always failed when not use GaoDe map, without any debug information.